### PR TITLE
feat(shared): auto-register default agent accounts

### DIFF
--- a/sidekick-cli/src/cli.ts
+++ b/sidekick-cli/src/cli.ts
@@ -3,7 +3,7 @@ declare const __CLI_VERSION__: string;
 import { Command } from 'commander';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { detectProvider } from 'sidekick-shared';
+import { detectProvider, ensureDefaultAccounts } from 'sidekick-shared';
 import { hydratePricingCatalog } from 'sidekick-shared/node';
 import type { ProviderId, SessionProvider } from 'sidekick-shared';
 import { ClaudeCodeProvider, OpenCodeProvider, CodexProvider } from 'sidekick-shared';
@@ -17,6 +17,10 @@ hydratePricingCatalog({
   /* non-fatal; static table still works */
 });
 
+const defaultAccountsReady = ensureDefaultAccounts().catch(() => {
+  /* non-fatal; account bootstrap must not block startup */
+});
+
 const program = new Command();
 
 program
@@ -26,6 +30,10 @@ program
   .option('--json', 'Output as JSON')
   .option('--project <path>', 'Override project path (default: cwd)')
   .option('--provider <id>', 'Provider: claude-code, opencode, codex, auto (default: auto)');
+
+program.hook('preAction', async () => {
+  await defaultAccountsReady;
+});
 
 export function resolveProviderId(
   opts: { provider?: string },

--- a/sidekick-shared/src/ensureDefaultAccounts.test.ts
+++ b/sidekick-shared/src/ensureDefaultAccounts.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import type { SavedAccountRegistry } from './accountRegistry';
+
+let tmpDir: string;
+
+vi.mock('./paths', () => ({
+  getConfigDir: () => tmpDir,
+}));
+
+vi.mock('./credentialIO', () => ({
+  readActiveCredentials: () => {
+    try {
+      return JSON.parse(fs.readFileSync(path.join(tmpDir, '.claude', '.credentials.json'), 'utf8'));
+    } catch {
+      return null;
+    }
+  },
+  writeActiveCredentials: (credentials: unknown) => {
+    const claudeDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(path.join(claudeDir, '.credentials.json'), JSON.stringify(credentials));
+  },
+}));
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return {
+    ...actual,
+    homedir: () => tmpDir,
+  };
+});
+
+import { getActiveSavedAccount, writeSavedAccountRegistry } from './accountRegistry';
+import { ensureDefaultAccounts } from './ensureDefaultAccounts';
+import { listAccounts } from './accounts';
+import { getActiveCodexAccount, getCodexProfilesDir, listCodexAccounts } from './codexProfiles';
+
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.signature`;
+}
+
+function writeClaudeSystemAccount(email = 'claude@example.com', uuid = 'claude-default'): void {
+  const claudeDir = path.join(tmpDir, '.claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(claudeDir, '.claude.json'),
+    JSON.stringify({ oauthAccount: { emailAddress: email, accountUuid: uuid } }),
+  );
+  fs.writeFileSync(
+    path.join(claudeDir, '.credentials.json'),
+    JSON.stringify({ claudeAiOauth: { accessToken: 'access-token', refreshToken: 'refresh-token' } }),
+  );
+}
+
+function writeCodexSystemAuth(email = 'codex@example.com'): void {
+  const codexHome = path.join(tmpDir, '.codex');
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.writeFileSync(path.join(codexHome, 'config.toml'), 'model = "gpt-5"\n');
+  fs.writeFileSync(
+    path.join(codexHome, 'auth.json'),
+    JSON.stringify({
+      auth_mode: 'chatgpt',
+      tokens: {
+        id_token: makeJwt({ email }),
+        access_token: 'codex-access-token',
+        refresh_token: 'codex-refresh-token',
+      },
+    }),
+  );
+}
+
+function countCodexProfileDirs(): number {
+  try {
+    return fs.readdirSync(getCodexProfilesDir()).length;
+  } catch {
+    return 0;
+  }
+}
+
+describe('ensureDefaultAccounts', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sidekick-ensure-default-accounts-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('registers default Claude and Codex accounts from system credentials', async () => {
+    writeClaudeSystemAccount('claude@example.com', 'claude-1');
+    writeCodexSystemAuth('codex@example.com');
+
+    const result = await ensureDefaultAccounts();
+
+    expect(result).toEqual({ claude: 'registered', codex: 'registered' });
+    expect(getActiveSavedAccount('claude-code')).toEqual(expect.objectContaining({
+      id: 'claude-1',
+      label: 'Default',
+      email: 'claude@example.com',
+    }));
+    expect(getActiveCodexAccount()).toEqual(expect.objectContaining({
+      label: 'Default',
+      email: 'codex@example.com',
+    }));
+  });
+
+  it('is idempotent when called repeatedly', async () => {
+    writeClaudeSystemAccount('claude@example.com', 'claude-1');
+    writeCodexSystemAuth('codex@example.com');
+
+    const first = await ensureDefaultAccounts();
+    const activeClaudeId = getActiveSavedAccount('claude-code')?.id;
+    const activeCodexId = getActiveCodexAccount()?.id;
+    const profileDirs = countCodexProfileDirs();
+    const second = await ensureDefaultAccounts();
+
+    expect(first).toEqual({ claude: 'registered', codex: 'registered' });
+    expect(second).toEqual({ claude: 'skipped', codex: 'skipped' });
+    expect(listAccounts()).toHaveLength(1);
+    expect(listCodexAccounts()).toHaveLength(1);
+    expect(getActiveSavedAccount('claude-code')?.id).toBe(activeClaudeId);
+    expect(getActiveCodexAccount()?.id).toBe(activeCodexId);
+    expect(countCodexProfileDirs()).toBe(profileDirs);
+  });
+
+  it('registers only Claude when only Claude credentials exist', async () => {
+    writeClaudeSystemAccount('claude@example.com', 'claude-1');
+
+    const result = await ensureDefaultAccounts();
+
+    expect(result).toEqual({ claude: 'registered', codex: 'skipped' });
+    expect(listAccounts()).toHaveLength(1);
+    expect(listCodexAccounts()).toHaveLength(0);
+  });
+
+  it('registers only Codex when only Codex auth exists', async () => {
+    writeCodexSystemAuth('codex@example.com');
+
+    const result = await ensureDefaultAccounts();
+
+    expect(result).toEqual({ claude: 'skipped', codex: 'registered' });
+    expect(listAccounts()).toHaveLength(0);
+    expect(listCodexAccounts()).toHaveLength(1);
+  });
+
+  it('does not overwrite existing active provider accounts', async () => {
+    const existing: SavedAccountRegistry = {
+      version: 2,
+      activeByProvider: {
+        'claude-code': 'claude-existing',
+        codex: 'codex-existing',
+      },
+      accounts: [
+        {
+          id: 'claude-existing',
+          providerId: 'claude-code',
+          providerAccountId: 'claude-existing',
+          email: 'existing-claude@example.com',
+          label: 'Existing Claude',
+          addedAt: '2026-04-01T00:00:00Z',
+        },
+        {
+          id: 'codex-existing',
+          providerId: 'codex',
+          email: 'existing-codex@example.com',
+          label: 'Existing Codex',
+          addedAt: '2026-04-01T00:00:00Z',
+        },
+      ],
+    };
+    writeSavedAccountRegistry(existing);
+    writeClaudeSystemAccount('new-claude@example.com', 'claude-new');
+    writeCodexSystemAuth('new-codex@example.com');
+
+    const result = await ensureDefaultAccounts();
+
+    expect(result).toEqual({ claude: 'skipped', codex: 'skipped' });
+    expect(getActiveSavedAccount('claude-code')?.id).toBe('claude-existing');
+    expect(getActiveCodexAccount()?.id).toBe('codex-existing');
+  });
+
+  it('logs and swallows registration failures', async () => {
+    const existing: SavedAccountRegistry = {
+      version: 2,
+      activeByProvider: {
+        'claude-code': null,
+        codex: null,
+      },
+      accounts: [
+        {
+          id: 'codex-inactive-default',
+          providerId: 'codex',
+          label: 'Default',
+          addedAt: '2026-04-01T00:00:00Z',
+        },
+      ],
+    };
+    writeSavedAccountRegistry(existing);
+    writeCodexSystemAuth('codex@example.com');
+    const logger = vi.fn();
+
+    const result = await ensureDefaultAccounts({ logger });
+
+    expect(result).toEqual({ claude: 'skipped', codex: 'error' });
+    expect(logger).toHaveBeenCalledWith(expect.stringContaining('Codex'), expect.anything());
+  });
+});

--- a/sidekick-shared/src/ensureDefaultAccounts.ts
+++ b/sidekick-shared/src/ensureDefaultAccounts.ts
@@ -1,0 +1,89 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { addCurrentAccount, readActiveClaudeAccount } from './accounts';
+import { getActiveSavedAccount } from './accountRegistry';
+import {
+  getActiveCodexAccount,
+  getCodexProfilesDir,
+  getSystemCodexHome,
+  prepareCodexAccount,
+} from './codexProfiles';
+import { readClaudeMaxCredentials } from './credentials';
+
+export type EnsureDefaultAccountStatus = 'registered' | 'skipped' | 'error';
+
+export interface EnsureDefaultAccountsResult {
+  claude: EnsureDefaultAccountStatus;
+  codex: EnsureDefaultAccountStatus;
+}
+
+export interface EnsureDefaultAccountsOptions {
+  logger?: (message: string, error?: unknown) => void;
+}
+
+function logFailure(options: EnsureDefaultAccountsOptions | undefined, message: string, error: unknown): void {
+  try {
+    options?.logger?.(message, error);
+  } catch {
+    // Logging must never make account bootstrap fail.
+  }
+}
+
+async function ensureDefaultClaudeAccount(
+  options: EnsureDefaultAccountsOptions | undefined,
+): Promise<EnsureDefaultAccountStatus> {
+  try {
+    if (getActiveSavedAccount('claude-code')) return 'skipped';
+
+    const active = readActiveClaudeAccount();
+    if (!active) return 'skipped';
+
+    const credentials = await readClaudeMaxCredentials();
+    if (!credentials) return 'skipped';
+
+    const result = addCurrentAccount('Default');
+    if (result.success) return 'registered';
+
+    logFailure(options, 'Claude default account registration failed.', result.error ?? 'unknown error');
+    return 'error';
+  } catch (error) {
+    logFailure(options, 'Claude default account registration failed.', error);
+    return 'error';
+  }
+}
+
+function cleanupPendingCodexProfile(profileId: string): void {
+  fs.rmSync(path.join(getCodexProfilesDir(), profileId), { recursive: true, force: true });
+}
+
+function ensureDefaultCodexAccount(
+  options: EnsureDefaultAccountsOptions | undefined,
+): EnsureDefaultAccountStatus {
+  try {
+    if (getActiveCodexAccount()) return 'skipped';
+
+    const systemAuthPath = path.join(getSystemCodexHome(), 'auth.json');
+    if (!fs.existsSync(systemAuthPath)) return 'skipped';
+
+    const result = prepareCodexAccount('Default');
+    if (result.success && !result.needsLogin) return 'registered';
+
+    if (result.profileId) {
+      cleanupPendingCodexProfile(result.profileId);
+    }
+    logFailure(options, 'Codex default account registration failed.', result.error ?? 'Codex auth could not be finalized.');
+    return 'error';
+  } catch (error) {
+    logFailure(options, 'Codex default account registration failed.', error);
+    return 'error';
+  }
+}
+
+export async function ensureDefaultAccounts(
+  options?: EnsureDefaultAccountsOptions,
+): Promise<EnsureDefaultAccountsResult> {
+  const claude = await ensureDefaultClaudeAccount(options);
+  const codex = ensureDefaultCodexAccount(options);
+
+  return { claude, codex };
+}

--- a/sidekick-shared/src/index.ts
+++ b/sidekick-shared/src/index.ts
@@ -273,6 +273,14 @@ export type { ClaudeMaxCredentials } from './credentials';
 
 // Accounts
 export {
+  ensureDefaultAccounts,
+} from './ensureDefaultAccounts';
+export type {
+  EnsureDefaultAccountStatus,
+  EnsureDefaultAccountsOptions,
+  EnsureDefaultAccountsResult,
+} from './ensureDefaultAccounts';
+export {
   readAccountRegistry,
   writeAccountRegistry,
   readActiveClaudeAccount,

--- a/sidekick-shared/src/packagingContract.test.ts
+++ b/sidekick-shared/src/packagingContract.test.ts
@@ -38,6 +38,11 @@ describe('packaging contract', () => {
     expect(typeof m.LITELLM_CATALOG_URL).toBe('string');
   });
 
+  it('dist/index.js exposes account bootstrap', () => {
+    const m = require(path.join(distDir, 'index.js'));
+    expect(typeof m.ensureDefaultAccounts).toBe('function');
+  });
+
   it('dist/browser.js does not transitively load node:fs or node:path', async () => {
     const src = await fs.readFile(browserJs, 'utf8');
     expect(src).not.toMatch(/require\(["']node:fs["']\)/);

--- a/sidekick-vscode/src/extension.ts
+++ b/sidekick-vscode/src/extension.ts
@@ -87,6 +87,7 @@ import { resolveModel } from "./services/ModelResolver";
 import { PROVIDER_DISPLAY_NAMES } from "./types/inferenceProvider";
 import { getNonce } from "./utils/nonce";
 import type { AccountProviderId } from 'sidekick-shared';
+import { ensureDefaultAccounts } from 'sidekick-shared';
 import { getRandomPhrase } from 'sidekick-shared/dist/phrases';
 import { hydratePricingCatalog } from 'sidekick-shared/node';
 
@@ -156,6 +157,10 @@ export async function activate(context: vscode.ExtensionContext) {
   const outputChannel = initLogger();
   context.subscriptions.push(outputChannel);
   log("Sidekick Agent Hub extension activated");
+
+  await ensureDefaultAccounts({
+    logger: (message, error) => logError(message, error),
+  });
 
   // Fire-and-forget hydrate the pricing catalog from LiteLLM so Codex/GPT
   // sessions display correct USD costs. Falls back to the static baseline if


### PR DESCRIPTION
## Description

Adds explicit default account bootstrap for Sidekick-managed Claude and Codex accounts. The new `ensureDefaultAccounts()` API auto-registers the first system Claude/Codex credentials when no active saved account exists for that provider, without overwriting manually added accounts.

This is wired into the CLI startup path and VS Code extension activation so quota and analytics consumers can see the default accounts without requiring users to manually save them first.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Component

- [x] VS Code Extension (`sidekick-vscode/`)
- [x] CLI (`sidekick-cli/`)
- [x] Shared Library (`sidekick-shared/`)
- [ ] Other (docs, CI, etc.)

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md)
- [x] My code follows the project's code style
- [x] I have tested my changes locally
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] All existing tests pass
- [x] I have updated documentation as needed

## Testing

Describe how you tested these changes:

1. Ran `npm run lint`, `npm test`, and `npm run build` in `sidekick-shared/`.
2. Ran `npm test`, `npm run lint`, and `npm run build` in `sidekick-cli/`.
3. Ran `npm test`, `npm run lint`, and `npm run compile` in `sidekick-vscode/`.
4. Manually verified `ensureDefaultAccounts()` registers Codex from local system `~/.codex/auth.json` when Claude is already registered and no Sidekick Codex account exists.
5. Manually verified a second `ensureDefaultAccounts()` call is idempotent and does not create duplicate accounts.
6. Verified downstream local consumer can load the local `sidekick-shared/dist/index.js`, register Codex, and read the resulting account from the shared on-disk registry.

## Screenshots (if applicable)

Not applicable. No UI changes.